### PR TITLE
Move check for \begin{thebibliography}

### DIFF
--- a/webapp/compiler/runner.py
+++ b/webapp/compiler/runner.py
@@ -88,16 +88,6 @@ def run_latex(cmd, input_dirname, output_dirname):
     if latexmkrc_file.is_file():
         warnings.append('File {} was removed before compiling'.format(latexmkrc_file.name))
         latexmkrc_file.unlink()
-    # Basic check if the authors inlined:
-    # \begin{thebibliography}
-    # in one of the .tex files recursively
-    for root, dirs, files in os.walk(staging_dir):
-        for filename in files:
-            if filename.endswith(".tex"):
-              curpath = os.path.join(root, filename)
-              with open(curpath, 'r', encoding='utf-8', errors='replace') as file:
-                  if '\\begin{thebibliography}' in file.read():
-                      raise ValueError('Do not include \\begin{thebibliography} directly in your text file: ' + filename)
     client = docker.from_env()
     try:
         # We mount the staging_dir as /data in the container.


### PR DESCRIPTION
I moved the check for \begin{thebibliography} to the /submit area, because compiler/runner.py runs in the ThreadPoolExecutor, and it's clumsy to handle exceptions there (I only handle system-related exceptions there, which should not happen). Things like checking for missing main.tex happens earlier in the routes.py before we submit it to the thread pool.